### PR TITLE
ci: run build against PRs

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -28,7 +28,9 @@ jobs:
         id: build
         continue-on-error: true
         run: |
+          set +e
           pnpm run build > build.txt
+          set -e
           BUILD=$(cat build.txt)
           BUILD="${BUILD//'%'/'%25'}"
           BUILD="${BUILD//$'\n'/'%0A'}"
@@ -39,7 +41,9 @@ jobs:
         id: compare
         continue-on-error: true
         run: |
+          set +e
           pnpm run compare > compare.txt
+          set -e
           COMPARE=$(cat compare.txt)
           COMPARE="${COMPARE//'%'/'%25'}"
           COMPARE="${COMPARE//$'\n'/'%0A'}"
@@ -50,7 +54,9 @@ jobs:
         id: chkimg
         continue-on-error: true
         run: |
+          set +e
           pnpm run check-images > chkimg.txt
+          set -e
           CHKIMG=$(cat chkimg.txt)
           CHKIMG="${CHKIMG//'%'/'%25'}"
           CHKIMG="${CHKIMG//$'\n'/'%0A'}"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -36,7 +36,6 @@ jobs:
           BUILD="${BUILD//$'\n'/'%0A'}"
           BUILD="${BUILD//$'\r'/'%0D'}"
           echo ::set-output name=output::$BUILD
-          echo $BUILD > $GITHUB_STEP_SUMMARY
       - name: Run build & set outputs
         id: compare
         continue-on-error: true
@@ -49,7 +48,6 @@ jobs:
           COMPARE="${COMPARE//$'\n'/'%0A'}"
           COMPARE="${COMPARE//$'\r'/'%0D'}"
           echo ::set-output name=output::$COMPARE
-          echo $COMPARE > $GITHUB_STEP_SUMMARY
       - name: Run check-images
         id: chkimg
         continue-on-error: true
@@ -62,7 +60,6 @@ jobs:
           CHKIMG="${CHKIMG//$'\n'/'%0A'}"
           CHKIMG="${CHKIMG//$'\r'/'%0D'}"
           echo ::set-output name=output::$CHKIMG
-          echo $CHKIMG > $GITHUB_STEP_SUMMARY
 
       - name: Comment PR
         uses: thollander/actions-comment-pull-request@v1

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -24,27 +24,39 @@ jobs:
         with:
           version: ^6.26.0
           run_install: true
-      - name: Run build & set outputs
+      - name: Run build
+        id: build
+        continue-on-error: true
         run: |
-          echo "::set-output name=hello::world"
           pnpm run build > build.txt
           BUILD=$(cat build.txt)
           BUILD="${BUILD//'%'/'%25'}"
           BUILD="${BUILD//$'\n'/'%0A'}"
           BUILD="${BUILD//$'\r'/'%0D'}"
-          echo ::set-output name=build::$BUILD
-          
+          echo ::set-output name=output::$BUILD
+          echo $BUILD > $GITHUB_STEP_SUMMARY
+      - name: Run build & set outputs
+        id: compare
+        continue-on-error: true
+        run: |
           pnpm run compare > compare.txt
           COMPARE=$(cat compare.txt)
           COMPARE="${COMPARE//'%'/'%25'}"
           COMPARE="${COMPARE//$'\n'/'%0A'}"
           COMPARE="${COMPARE//$'\r'/'%0D'}"
-          echo ::set-output name=compare::$COMPARE
-        id: build
+          echo ::set-output name=output::$COMPARE
+          echo $COMPARE > $GITHUB_STEP_SUMMARY
       - name: Run check-images
-        run: pnpm run check-images
-        continue-on-error: true
         id: chkimg
+        continue-on-error: true
+        run: |
+          pnpm run check-images > chkimg.txt
+          CHKIMG=$(cat chkimg.txt)
+          CHKIMG="${CHKIMG//'%'/'%25'}"
+          CHKIMG="${CHKIMG//$'\n'/'%0A'}"
+          CHKIMG="${CHKIMG//$'\r'/'%0D'}"
+          echo ::set-output name=output::$CHKIMG
+          echo $CHKIMG > $GITHUB_STEP_SUMMARY
 
       - name: Comment PR
         uses: thollander/actions-comment-pull-request@v1
@@ -58,7 +70,7 @@ jobs:
             <summary> Output of `pnpm run build`:</summary>
             
             ```sh
-            ${{ steps.build.outputs.build }}
+            ${{ steps.build.outputs.output }}
             ```
             </details>
 
@@ -67,14 +79,20 @@ jobs:
             <summary> Output of `pnpm run compare`:</summary>
             
             ```sh
-            ${{ steps.build.outputs.compare }}
+            ${{ steps.compare.outputs.output }}
+            </details>
             ```
             
             ## Check-images
-            Status: `${{ steps.chkimg.outcome }}`
+            <details open>
+            <summary> Output of `pnpm run check-images`:</summary>
+            
+            ```sh
+            ${{ steps.chkimg.outputs.output }}
+            ```
             </details>
           comment_includes: 'Output of'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Set job result
-        if: steps.chkimg.outcome != 'success'
+        if: steps.build.outcome != 'success' || steps.compare.outcome != 'success' || steps.chkimg.outcome != 'success'
         run: exit 1

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,80 @@
+---
+name: PR
+# This workflow is meant to check every PR and create (or update) a comment with helpful logs.
+
+on: pull_request
+
+jobs:
+  pr:
+    name: Check PR
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Cache pnpm modules
+        uses: actions/cache@v2
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-
+      - uses: pnpm/action-setup@v2.0.1
+        with:
+          version: ^6.26.0
+          run_install: true
+      - name: Run build & set outputs
+        run: |
+          echo "::set-output name=hello::world"
+          pnpm run build > build.txt
+          BUILD=$(cat build.txt)
+          BUILD="${BUILD//'%'/'%25'}"
+          BUILD="${BUILD//$'\n'/'%0A'}"
+          BUILD="${BUILD//$'\r'/'%0D'}"
+          echo ::set-output name=build::$BUILD
+          
+          pnpm run compare > compare.txt
+          COMPARE=$(cat compare.txt)
+          COMPARE="${COMPARE//'%'/'%25'}"
+          COMPARE="${COMPARE//$'\n'/'%0A'}"
+          COMPARE="${COMPARE//$'\r'/'%0D'}"
+          echo ::set-output name=compare::$COMPARE
+        id: build
+      - name: Run check-images
+        run: pnpm run check-images
+        continue-on-error: true
+        id: chkimg
+
+      - name: Comment PR
+        uses: thollander/actions-comment-pull-request@v1
+        with:
+          message: |
+            # PR Status
+            <small>Commit: ${{ github.sha }}</small>
+            
+            ## Build
+            <details open>
+            <summary> Output of `pnpm run build`:</summary>
+            
+            ```sh
+            ${{ steps.build.outputs.build }}
+            ```
+            </details>
+
+            ## Compare
+            <details open>
+            <summary> Output of `pnpm run compare`:</summary>
+            
+            ```sh
+            ${{ steps.build.outputs.compare }}
+            ```
+            
+            ## Check-images
+            Status: `${{ steps.chkimg.outcome }}`
+            </details>
+          comment_includes: 'Output of'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set job result
+        if: steps.chkimg.outcome != 'success'
+        run: exit 1


### PR DESCRIPTION
# Goal
I've created a new Github Action to run against every pull request and do the following things:

- run `pnpm run build`
- capture output
- run `pnpm run compare`
- capture output
- run `pnpm run check-images`
- if the command fails, mark the check as failing

The action is using [thollander/actions-comment-pull-request](https://github.com/thollander/actions-comment-pull-request) to then create a comment with the captured output of the first two commands, like this:
![img](https://user-images.githubusercontent.com/6183867/179423649-c7c69e14-2390-4233-a0d4-c7bce0f90b4e.png)

If there's been already a comment (so the PR is updated), the bot is updating the existing comment with the latest status instead of making a new one, making it easier to see for the reviewer.

## Examples 
- MatyiFKBT/Meta/pull/3
- MatyiFKBT/Meta/pull/4

## Useful links
- https://stackoverflow.com/q/59191913/17024990
- https://github.community/t/set-output-truncates-multiline-strings/16852/2
- actions/toolkit/issues/403

<small>Merging this should close MatyiFKBT/Meta/pull/3 and MatyiFKBT/Meta/pull/4 </small>