### PR TITLE
use shorthand syntax for UnBirthdayMailboxScatter items

### DIFF
--- a/items/cards/2022unbirthday.cz
+++ b/items/cards/2022unbirthday.cz
@@ -42,17 +42,11 @@ UnBirthdayMailboxCard {
     Bread-and-Butterfly Card
 ]
 
-UnBirthdayMailboxScatter {
-    name = Drink Me Potion
-    id = 3896
-}
-
-UnBirthdayMailboxScatter {
-    name = Eat Me Cookie
-    id = 3897
-}
-
-UnBirthdayMailboxScatter {
-    name = Bread-and-Butterfly
-    id = 3898
-}
+UnBirthdayMailboxScatter { 
+    name = .1
+    id = $(.2 || 3896 + .index)
+} for [
+    Drink Me Potion
+    Eat Me Cookie
+    Bread-and-Butterfly
+]


### PR DESCRIPTION
Since the indexing of the scatter IDs start at 3896, we can use the same syntax here as for the mailbox cards.

(also, let's see the new PR action!)